### PR TITLE
Upgraded dependency on Perl::Critic v1.126.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -51,5 +51,5 @@ repository.web = http://github.com/reneeb/Perl-Critic-RENEEB
 repository.type = git
 
 [Prereqs]
-Perl::Critic = 1.105
+Perl::Critic = 1.126
 Readonly = 1.03


### PR DESCRIPTION
Hi @reneeb 

Please review the PR.
I noticed all the fail report showing Perl::Critic v1.125 or less installed.

In my humble opinion, anything v1.125 or less are buggy and cause these failures. I had v1.132 (latest) which happily passed all the tests. Then I downgraded it to v1.125 and I got the same error as reported in the fail reports. After that I upgraded to v1.126 and no error this time. So I propose, we should upgrade the dependency on Perl::Critic v1.126.

https://www.cpantesters.org/cpan/report/ba5984ad-6bf8-1014-9f38-23fa8160ed4f

Many Thanks.
Best Regards,
Mohammad S Anwar
 